### PR TITLE
[프로그래머스 - Lv. 1] 2016년

### DIFF
--- a/bangdori/2016년.js
+++ b/bangdori/2016년.js
@@ -1,0 +1,15 @@
+WEEKS = 7;
+
+months = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+daysOfWeek = ["THU", "FRI", "SAT", "SUN", "MON", "TUE", "WED"];
+
+function solution(a, b) {
+  const numberOfDate = calculateNumberOfDate(a, b);
+  const answer = daysOfWeek[numberOfDate % WEEKS];
+
+  return answer;
+}
+
+function calculateNumberOfDate(month, day) {
+  return months.slice(0, month - 1).reduce((acc, curr) => acc + curr, day);
+}


### PR DESCRIPTION
## 문제

| Type         | Info |
| :----------- | :--- |
| **Platform** |  프로그래머스    |
| **Level**    |   Level. 1   |
| **Link**     |   https://school.programmers.co.kr/learn/courses/30/lessons/12901   |

## 풀이

- 1월 1일을 1이라고 가정하면 1월 2일은 2, 1월 3일은 3, ... 1월 7일은 7, 1월 8일은 8, ....
- 요일은 7일을 주기로 변환되기 때문에 a월 b일이 주어진다면 a월이 되기까지의 일수 + b일을 계산
- 합한 결과를 7일로 나누어서 요일을 반환

### 중요 포인트

1. 문제에서 주어진 2016년은 **윤년**이기 때문에 1년이 366일, 2월이 29일까지 존재한다.
2. 1일이 금요일이 때문에 배열을 생성할때는 0번째 인덱스는 목요일이 되어야한다.

## 어려웠던 점

- [ ] 1월부터 12월까지의 일수를 명확하게 알지 못한다면 어떻게 해야할까요?

## 알게된 점

### 1. JavasScript `slice()` vs `splice()` 

- `slice`는 원본 배열을 유지한 채 begin ~ end까지에 대한 새로운 배열 객체를 반환
- `splice`는 begin부터 delCount만큼의 요소를 제거한 후 삭제된 요소를 포함한 배열을 반환

```js
const numbers = [1, 2, 3, 4, 5];

console.log(numbers.slice(1, 3)); // [2, 3]
console.log(numbers); // [1, 2, 3, 4, 5]

console.log(numbers.splice(1, 3)); [2, 3, 4]
console.log(numbers); // [1, 5]
```