### PR TITLE
[Leetcode - Medium] Shortest Bridge

### DIFF
--- a/bangdori/Shortest Bridge.js
+++ b/bangdori/Shortest Bridge.js
@@ -1,0 +1,94 @@
+const WATER = 0;
+const ISLAND = 1;
+const ISLAND2 = 2;
+const DIRS = [
+  [-1, 0],
+  [1, 0],
+  [0, -1],
+  [0, 1],
+];
+
+/**
+ * @param {number[][]} grid
+ * @return {number}
+ */
+var shortestBridge = function (grid) {
+  const rows = grid.length;
+  const cols = grid[0].length;
+
+  let queue = [];
+
+  const exploreIslandDFS = (row, col) => {
+    if (grid[row][col] === ISLAND2) return;
+
+    grid[row][col] = ISLAND2;
+    queue.push([row, col]);
+
+    for (let [dx, dy] of DIRS) {
+      const nextRow = row + dx;
+      const nextCol = col + dy;
+
+      if (
+        nextRow >= 0 &&
+        nextRow < rows &&
+        nextCol >= 0 &&
+        nextCol < cols &&
+        grid[nextRow][nextCol] === ISLAND
+      ) {
+        exploreIslandDFS(nextRow, nextCol);
+      }
+    }
+  };
+
+  const connectIslandBFS = () => {
+    /**
+     * 이동 거리를 나타내는 변수
+     * ISLAND와 차이를 두기 위해 음수값으로 적용
+     */
+    let distance = -1;
+    let currentQueue = queue;
+
+    while (currentQueue.length > 0) {
+      queue = [];
+
+      for (const [row, col] of currentQueue) {
+        for (const [dx, dy] of DIRS) {
+          const nextRow = row + dx;
+          const nextCol = col + dy;
+
+          if (
+            nextRow >= 0 &&
+            nextRow < rows &&
+            nextCol >= 0 &&
+            nextCol < cols
+          ) {
+            if (grid[nextRow][nextCol] === WATER) {
+              queue.push([nextRow, nextCol]);
+              grid[nextRow][nextCol] = distance;
+            }
+
+            if (grid[nextRow][nextCol] === ISLAND) {
+              return (distance + 1) * -1;
+            }
+          }
+        }
+      }
+
+      distance -= 1;
+      currentQueue = queue;
+    }
+
+    return 1;
+  };
+
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      if (grid[r][c] === WATER) continue;
+
+      exploreIslandDFS(r, c);
+      return connectIslandBFS();
+    }
+  }
+
+  return -1; // Error
+};

--- a/bangdori/Shortest Bridge.js
+++ b/bangdori/Shortest Bridge.js
@@ -29,10 +29,7 @@ var shortestBridge = function (grid) {
       const nextCol = col + dy;
 
       if (
-        nextRow >= 0 &&
-        nextRow < rows &&
-        nextCol >= 0 &&
-        nextCol < cols &&
+        isValidCoords(nextRow, nextCol) &&
         grid[nextRow][nextCol] === ISLAND
       ) {
         exploreIslandDFS(nextRow, nextCol);
@@ -56,12 +53,7 @@ var shortestBridge = function (grid) {
           const nextRow = row + dx;
           const nextCol = col + dy;
 
-          if (
-            nextRow >= 0 &&
-            nextRow < rows &&
-            nextCol >= 0 &&
-            nextCol < cols
-          ) {
+          if (isValidCoords(nextRow, nextCol)) {
             if (grid[nextRow][nextCol] === WATER) {
               queue.push([nextRow, nextCol]);
               grid[nextRow][nextCol] = distance;
@@ -80,6 +72,9 @@ var shortestBridge = function (grid) {
 
     return 1;
   };
+
+  const isValidCoords = (row, col) =>
+    row >= 0 && row < rows && col >= 0 && col < cols;
 
   for (let r = 0; r < rows; r++) {
     for (let c = 0; c < cols; c++) {


### PR DESCRIPTION
## 문제

| Type         | Info |
| :----------- | :--- |
| **Platform** |  Leetcode    |
| **Level**    |  Medium    |
| **Link**     |  https://leetcode.com/problems/shortest-bridge/    |

## 풀이

1. DFS로 첫 번째 섬을 탐색
   - 첫 번째 섬의 모든 좌표를 방문하며, 두 번째 섬과 구분하기 위해 다른 값(`ISLAND2`)으로 변경한다.
   - 방문한 좌표를 BFS 큐에 추가한다.
2. BFS로 다리 길이 계산
   - 첫 번째 섬의 좌표를 시작점으로 하여 바다(`WATER`)를 탐색하며 확장해 나간다.
      - 탐색한 바다는 첫 번째 섬으로 부터의 거리 값(`distance`)으로 변환한다.
      - ⭐️ 거리 값(`distance`)은 두 번째 섬과 동일한 값으로 분류될 수 있기 때문에 음수로 저장한다.
   - 다른 섬(`ISLAND`)에 도달할 때까지 BFS를 반복하며 다리의 길이를 계산한다.

## 어려웠던 점

- BFS를 구현하는데 DFS와 개념을 혼용해서, BFS에서 배열의 첫 번째 인자를 어떻게 O(1)로 가져올 수 있을지에 대해 고민을 한다고 너무 많은 시간을 사용함...

## 알게된 점

- BFS는 깊이 우선 탐색으로, 자바스크립트에서 재귀 함수를 이용해서 구현할 수 있음
- DFS는 너비 우선 탐색으로, 자바스크립트에서 Stack 배열을 통해 구현할 수 있음