### PR TITLE
[LeetCode - Medium] Top K Frequent Elements

### DIFF
--- a/suhwan2004/Top K Frequent Elements.js
+++ b/suhwan2004/Top K Frequent Elements.js
@@ -1,0 +1,41 @@
+//16:19 ~ 16:44
+
+/*
+M = 10^4, N = 10^5
+Time : O(N)
+Space : O(N)
+ALGO : for
+DS : HashMap, Array
+Edge Case : X
+Constraints :
+- 1 <= nums.length <= 10^5
+- -10^4 <= nums[i] <= 10^4
+- k is in the range [1, the number of unique elements in the array].
+- It is guaranteed that the answer is unique.
+
+nums를 순회하면서 hashmap에 key는 현제 나온 값, value는 해당 값이 지금까지 나온 횟수로써 추가해준다.
+
+이후, hashMap을 배열화 해서 한번 돌면서 배열안에 나온 횟수 인덱스에 현재 값을 넣어준다
+arr[value].push(key)
+
+뒤를 돌면서 원하는 순위까지만큼 찾아서 k가 채워질 정도 까지만 push 하고 반환해준다
+
+*/
+var topKFrequent = function(nums, k) {
+    const map = new Map(); // Space : O(N)
+    let arr = []; // Space : O(2*M  =>  M)
+    let res = []; // Space : O(M)
+    nums.forEach((num) => map.set(num, (map.get(num) || 0) + 1)); // Time : O(N)
+    
+    for (let [key, value] of map.entries()) { // Time : O(N)
+        if(arr[value]) arr[value].push(key);
+        else arr[value] = [key];
+    }
+
+    for(let i = arr.length -1; i >= 0; i--){ // Space : O(M)
+        if(arr[i])res.push(...arr[i].slice(0, k - res.length))
+        if(res.length === k) break;
+    }
+
+    return res;
+};


### PR DESCRIPTION
## 문제

| Type                 | Info |
| :------------------- | :--- |
| **Time Complexity**  |   O(N)    |
| **Space Complexity** |   O(N)   |
| **Algorithm**        |   For   |
| **Data Structure**   |   Array, Hash Map   |

## Constraints
- 입력값으로 number[]인 nums, number인 k가 주어진다
- 1 <= nums.length <= 10^5
- -10^4 <= nums[i] <= 10^4
- k 의 범위는 [1, 배열 내 고유한 숫자 갯수] 이다.
- 문제의 답은 항상 고유하다.

## Edge Case
X

## 풀이
1. 입력받는 nums를 순회하면서 hashmap에 key는 현제 나온 값, value는 해당 값이 지금까지 나온 횟수로써 추가해준다.
2. hashMap을 배열화 해서 한번 돌면서 배열안에 나온 횟수 인덱스에 현재 값을 넣어준다
    다음과 같이 => arr[value].push(key)

3. 배열의 맨 마지막 인덱스부터 0까지 for로 순회하며, 원하는 순위까지만큼 찾아서 k가 채워질 정도 까지만 push 하고 반환해준다

## 어려웠던 점
X

## 알게된 점
JS의 HashMap의 공간복잡도는 오버헤드에 늘어날 수 있으나 N만큼의 값을 저장할 시에 O(N)에 가깝다...? 라고 GPT가 말하는데
막상 인터넛에도 공간복잡도는 O(N) 이다~ 라고 글이 써있지만 자세히 적혀있는 사이트를 찾지 못했네요...


js의 hash map이 공간복잡도가 O(N)인 이유:
1.각 키-값 쌍의 저장:
HashMap은 N개의 고유 키-값 쌍을 저장해야 하므로, 최소한 N개의 공간이 필요합니다.
각 키와 값은 메모리에 저장되며, 각각 추가적인 메모리를 소비합니다.

2.해시 충돌 처리:
해시 충돌이 발생하면 동일한 해시 값을 가진 키들을 처리하기 위해 추가적인 공간(예: 배열이나 연결 리스트)이 필요합니다.
충돌이 적다면 추가 공간 사용은 적습니다. 하지만 최악의 경우에는 모든 요소가 한 버킷에 저장될 수 있어 O(N)의 공간이 필요합니다.

3.오버헤드 (Load Factor):
HashMap은 일반적으로 "로드 팩터"에 따라 버킷 크기를 조정합니다.
예를 들어, 로드 팩터가 0.75라면, N개의 요소를 저장하려면 약 1.33N개의 버킷이 필요합니다.
이 여분의 공간도 공간복잡도 O(N)에 포함됩니다.