### PR TITLE
[Leetcode - Medium] Restore Ip Addresses

### DIFF
--- a/suhwan2004/Restore IP Addresses.js
+++ b/suhwan2004/Restore IP Addresses.js
@@ -1,0 +1,37 @@
+/*
+18:55 ~ 19:36 
+Time : O(3^4) => O(1)
+Space : O(3^4) => O(1)
+ALGO : dfs, for
+DS : array
+Constraints : 
+- 1 <= s.length <= 20
+- s는 무조건 숫자로 이루어져 있다
+Edge Case : 12보다 s의 길이가 크면 절대 ip로 만들어질 수 없기에 빈 배열 반환
+*/
+var restoreIpAddresses = function(s) {
+    if(s.length > 12) return []
+    return dfs(s, 0, [], [])
+};
+
+const dfs = (s, pos, arr, res) => {
+    if(arr.length > 4) return res
+    if(pos >= s.length && arr.length === 4){
+        res.push(arr.join("."))
+        return res
+    }
+
+    for(let i = pos + 1 ; i <= Math.min(s.length, pos + 3); i++){
+        const curStr = s.slice(pos, i)
+        const curNum = Number(curStr)
+
+        if(curStr[0] === '0' && curStr.length > 1) continue
+        if(curNum >= 0 && curNum <= 255) {
+            arr.push(curNum)
+            dfs(s, i, arr, res)
+            arr.pop(curNum)
+        }
+    }
+
+    return res
+}


### PR DESCRIPTION
## 문제

| Type                 | Info |
| :------------------- | :--- |
| **Time Complexity**  |   O(3^4) =>  O(1)  |
| **Space Complexity** |   O(3^4) =>  O(1)   |
| **Algorithm**        |   dfs, for, backtracking   |
| **Data Structure**   |   array   |

## Constraints
- 1 <= s.length <= 20
- s는 무조건 숫자로 이루어져 있다

## Edge Case
12보다 s의 길이가 크면 절대 ip로 만들어질 수 없기에 빈 배열 반환

## 풀이
1. dfs를 돌 때, 마지막으로 점을 찍은 자릿수(pos)를 저장한다.
2. 만약, IP를 구성하기 위해 쪼갠 문자열 배열(arr)이 4개 보다 많다면 IP가 성립할 수 없기에 그냥 return한다.
3. 만약, pos가 s의 길이만큼 되었고, arr의 길이가 4라면 제대로된 IP이기에 res에 push한다.

4. 2~3의 케이스가 아니라면, pos를 기준으로 시작점을 잡고, 이 시작점에서 한자리 ~ 세자리 사이의 숫자를 만들어서 arr에 넣고 다음 재귀로 넘어간다.
  => 다만, 해당 숫자가 0 ~ 255 사이여야 하며, 또한 0이 앞에 있으면 넘어가지 않는다.

## 어려웠던 점
X

## 알게된 점
X